### PR TITLE
fix: remove nvidia module parameters that do nothing in attachgpu.sh

### DIFF
--- a/scripts/attachgpu.sh
+++ b/scripts/attachgpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 rmmod vfio_pci vfio_pci_core vfio_iommu_type1 vfio
 modprobe nvidia_drm modeset=1 fbdev=0
-modprobe nvidia nvidia_modeset nvidia_uvm 
+modprobe nvidia
 echo -n "0000:01:00.1" > /sys/bus/pci/drivers/snd_hda_intel/bind
 
 #setup currentenv for gpu loader switching


### PR DESCRIPTION
If you want the behavior of loading all those modules you would use `modprobe -a nvidia nvidia_modeset nvidia_uvm`.